### PR TITLE
Add Laravel framework version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Piplin
+# Piplin - [![Composer Cache](https://shield.with.social/cc/github/Piplin/Piplin/master.svg?style=flat-square)](https://packagist.org/packages/laravel/framework)
 
 [![StyleCI](https://styleci.io/repos/67609292/shield)](https://styleci.io/repos/67609292/)
 [![Build Status](https://travis-ci.org/Piplin/Piplin.svg?branch=master)](https://travis-ci.org/Piplin/Piplin)


### PR DESCRIPTION
I've added it to read the master branch. Can change it to `1.0` or similar.

Hope this helps people see the current version you're using :+1: