### PR TITLE
Fix incorrect access to the project's property

### DIFF
--- a/app/Bus/Jobs/PurgeProjectJob.php
+++ b/app/Bus/Jobs/PurgeProjectJob.php
@@ -66,11 +66,11 @@ class PurgeProjectJob extends Job implements ShouldQueue
             $this->project->buildPlan->forceDelete();
         }
 
-        foreach ($this->project->commands as $command) {
+        foreach ($this->project->deployPlan->commands as $command) {
             $command->environments()->detach();
         }
 
-        foreach ($this->project->environments as $environment) {
+        foreach ($this->project->deployPlan->environments as $environment) {
             $environment->commands()->detach();
             $environment->configFiles()->detach();
 

--- a/app/Http/Controllers/Api/IncomingWebhookController.php
+++ b/app/Http/Controllers/Api/IncomingWebhookController.php
@@ -174,7 +174,7 @@ class IncomingWebhookController extends Controller
 
         // Check if the commands input is set, if so explode on comma and filter out any invalid commands
         if ($request->has('commands')) {
-            $valid     = $project->commands->pluck('id');
+            $valid     = $project->deployPlan->commands->pluck('id');
             $requested = explode(',', $request->get('commands'));
 
             $payload['optional'] = collect($requested)->unique()

--- a/app/Http/Controllers/Api/IncomingWebhookController.php
+++ b/app/Http/Controllers/Api/IncomingWebhookController.php
@@ -184,7 +184,7 @@ class IncomingWebhookController extends Controller
 
         $payload['environments'] = [];
         if ($request->has('environments')) {
-            $valid     = $project->environments->pluck('id');
+            $valid     = $project->deployPlan->environments->pluck('id');
             $requested = explode(',', $request->get('environments'));
 
             $payload['environments'] = collect($requested)->unique()

--- a/app/Http/Controllers/Dashboard/EnvironmentController.php
+++ b/app/Http/Controllers/Dashboard/EnvironmentController.php
@@ -39,7 +39,7 @@ class EnvironmentController extends Controller
     {
         $project = $deployPlan->project;
 
-        $optional = $project->commands->filter(function (Command $command) {
+        $optional = $project->deployPlan->commands->filter(function (Command $command) {
             return $command->optional;
         });
 

--- a/app/Http/Controllers/Dashboard/ProjectController.php
+++ b/app/Http/Controllers/Dashboard/ProjectController.php
@@ -52,7 +52,7 @@ class ProjectController extends Controller
             ],
         ];
 
-        $data['environments'] = $project->environments;
+        $data['environments'] = $project->deployPlan->environments;
         if ($tab === 'hooks') {
             $data['hooks'] = $project->hooks;
             $data['title'] = trans('hooks.label');

--- a/app/Http/Controllers/Dashboard/ProjectController.php
+++ b/app/Http/Controllers/Dashboard/ProjectController.php
@@ -36,7 +36,7 @@ class ProjectController extends Controller
      */
     public function show(Project $project, $tab = '')
     {
-        $optional = $project->commands->filter(function (Command $command) {
+        $optional = $project->deployPlan->commands->filter(function (Command $command) {
             return $command->optional;
         });
 

--- a/app/Http/Controllers/Dashboard/TaskController.php
+++ b/app/Http/Controllers/Dashboard/TaskController.php
@@ -120,7 +120,7 @@ class TaskController extends Controller
         ];
 
         /*
-        if ($project->environments->count() === 0) {
+        if ($project->deployPlan->environments->count() === 0) {
             return [
                 'success' => false,
             ];

--- a/resources/views/dashboard/deployments/_dialogs/environment.blade.php
+++ b/resources/views/dashboard/deployments/_dialogs/environment.blade.php
@@ -36,7 +36,7 @@
 									{{ trans('environments.default_description') }}
 								</label>
 							</div>
-							@if (Route::currentRouteName() == 'projects' && $project->commands->count() > 0)
+							@if (Route::currentRouteName() == 'projects' && $project->deployPlan->commands->count() > 0)
 							<div class="checkbox" id="add-environment-command">
 								<label class="control-label" for="environment_commands">
 									<input type="checkbox" value="1" name="commands" id="environment_commands" checked />


### PR DESCRIPTION
在修改Webhook部分的代码时，发现了$project->environments、$project->commands等属性是不存在的，在这里一并修改了。另外PurgeProjectJob里面有类似$this->project->commands()->forceDelete();这样的调用，这个是否需要修改？这部分我没有测试。