### PR TITLE
use softdelete to fix a db error.

### DIFF
--- a/app/Http/Controllers/Admin/CabinetController.php
+++ b/app/Http/Controllers/Admin/CabinetController.php
@@ -129,7 +129,7 @@ class CabinetController extends Controller
      */
     public function destroy(Cabinet $cabinet)
     {
-        $cabinet->forceDelete();
+        $cabinet->delete();
 
         return [
             'success' => true,


### PR DESCRIPTION
there is an error [Integrity constraint violation: 1451 Unknown error 1451] when delete a cabinet which has a soft deleted project.
so a soft delete for cabinet is needed to fix this error.